### PR TITLE
Potential fix for code scanning alert no. 4: Missing rate limiting

### DIFF
--- a/controllers/apiController.js
+++ b/controllers/apiController.js
@@ -18,6 +18,13 @@ const addToCartLimiter = rateLimit({
   message: "Too many requests, please try again later."
 });
 
+// Create a rate limiter for shop browsing
+const shopLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 min
+  max: 100,
+  message: "Too many requests on shop, please try again later."
+});
+
 /* Using AWS Secrets Manager to secure stripe_sk instead of exposed in code/configurations*/
 var awssecrets = require('../aws/aws-secrets');
 awssecrets.handler().then(function (data) {
@@ -30,7 +37,7 @@ module.exports = function (app) {
     app.use(bodyParser.json());
     app.use(bodyParser.urlencoded({ extended: true }));
 
-    app.get(['/shop', '/'], function (req, res) {
+    app.get(['/shop', '/'], shopLimiter, function (req, res) {
         var currentCart = new cart(req.session.cart);
         catalogs.find({},
             function (err, results) {


### PR DESCRIPTION
Potential fix for [https://github.com/lafatsta/stripe/security/code-scanning/4](https://github.com/lafatsta/stripe/security/code-scanning/4)

To resolve the issue, we should apply a rate-limiting middleware to the `/shop` and `/` GET routes. A rate limiter can be defined using the `express-rate-limit` package, as is already done in the code for `/addToCart/:productID`. For consistency, we can define a separate rate limiter for shop browsing (e.g., 100 requests per 15 minutes per IP), or reuse the existing configuration style, and apply it directly to the `/shop` and `/` route handler in the `app.get` call. Only lines affecting the `/shop` and `/` route should be changed, leaving other routes and application logic untouched. If not already present, define a new limiter for this purpose alongside `addToCartLimiter`.

**Changes required:**
- Define a new `shopLimiter` using `rateLimit`.
- Apply `shopLimiter` in the `app.get(['/shop', '/'], ...)` route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
