### PR TITLE
Potential fix for code scanning alert no. 3: Clear text transmission of sensitive cookie

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,10 @@ awssecrets.handler().then(function (data) {
 
 
 
+
+// Ensure cookies are only sent over HTTPS in production
+if (!constants.sessionOptions.cookie) constants.sessionOptions.cookie = {};
+constants.sessionOptions.cookie.secure = process.env.NODE_ENV === 'production';
 app.use(session(constants.sessionOptions));
 app.set('view engine', 'pug');
 app.use(express.static('public'));


### PR DESCRIPTION
Ensure session cookie is set with the `secure` attribute, so it is only ever transmitted over HTTPS connections.  